### PR TITLE
Add CLAUDE.md documentation for Coding4Conservation site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md — Coding4Conservation Website
+
+This site shares the same base Jekyll structure as the [Brook Lab website](https://github.com/brooklabteam/www). Refer to that repository's [CLAUDE.md](https://github.com/brooklabteam/www/blob/main/CLAUDE.md) for guidance on local development, repository structure, adding content, and deployment — everything there applies here as well.
+
+## Site-Specific Notes
+
+- **Site URL:** `https://coding4conservation.org`
+- **Top-level pages:** `index.md`, `mentors.md`, `preparation.md`, `students.md`, `syllabus.md`
+- Nav links are hardcoded in `_includes/header.html`.


### PR DESCRIPTION
## Summary
Added a CLAUDE.md file to document the Coding4Conservation website structure and development guidelines, following the same pattern as the Brook Lab website.

## Changes
- Created `CLAUDE.md` with site-specific documentation that:
  - References the Brook Lab website repository as the source of truth for development, structure, content, and deployment guidance
  - Documents the site URL (`https://coding4conservation.org`)
  - Lists the top-level pages (`index.md`, `mentors.md`, `preparation.md`, `students.md`, `syllabus.md`)
  - Notes that navigation links are hardcoded in `_includes/header.html`

## Details
This documentation file serves as a quick reference for developers working on the Coding4Conservation site, directing them to the shared Jekyll base structure while highlighting site-specific configuration details.

https://claude.ai/code/session_015YC1xVWo2H2yYWNTig31ZL