### PR TITLE
Update domain registrar from Squarespace to Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ### Basics
 
-**www-coding4conservation** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Squarespace](https://domains.squarespace.com).
+**www-coding4conservation** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Cloudflare](https://www.cloudflare.com).
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/868286f8-b544-43a5-932d-f2711605221d/deploy-status)](https://app.netlify.com/sites/coding4conservation/deploys)


### PR DESCRIPTION
## Summary
Updated the README to reflect a change in the domain registrar for the www-coding4conservation website.

## Changes
- Updated the domain registrar reference from Squarespace to Cloudflare in the README's Basics section
- This change documents that the domain is now registered and managed through Cloudflare instead of Squarespace Domains

## Details
The deployment infrastructure remains the same (Jekyll for static site generation and Netlify for hosting), with only the domain registration provider being updated in the documentation.

https://claude.ai/code/session_01A6VX2ADhsfBYsLDZxuDZnN