### PR TITLE
Configure Bundler to exclude development and test gems

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: "development:test"


### PR DESCRIPTION
## Summary
Added Bundler configuration to exclude development and test gem groups from being installed by default.

## Changes
- Created `.bundle/config` with `BUNDLE_WITHOUT` setting to skip `development` and `test` gem groups during bundle installation

## Details
This configuration is useful for production environments where development and test dependencies are not needed, reducing the bundle size and installation time. When `bundle install` is run, it will now automatically exclude gems from the development and test groups unless explicitly overridden.

https://claude.ai/code/session_01SEZ3au7L9odhAkPhkPPkAv