### PR TITLE
Replace Plausible Analytics redirects with dynamic proxy function

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,9 +1,3 @@
-# netlify redirects https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
-
-# Plausible Analytics based on https://plausible.io/docs/proxy/guides/vercel
-/pio/js/pa-s49MQh6vkUW1n3PK9sukW.js https://plausible.io/js/pa-s49MQh6vkUW1n3PK9sukW.js 200
-/pio/api/event https://plausible.io/api/event 200
-
 # Redirects from changing page URLs
 /mentor-profiles /mentors
 /student-profiles /students

--- a/functions/pio/[[path]].js
+++ b/functions/pio/[[path]].js
@@ -1,0 +1,18 @@
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const plausiblePath = url.pathname.replace(/^\/pio/, "") + url.search;
+
+  const response = await fetch("https://plausible.io" + plausiblePath, {
+    method: context.request.method,
+    headers: context.request.headers,
+    body: context.request.method === "POST" ? context.request.body : undefined,
+  });
+
+  const newHeaders = new Headers(response.headers);
+  newHeaders.delete("set-cookie");
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: newHeaders,
+  });
+}


### PR DESCRIPTION
## Summary
Replaced static Netlify redirects for Plausible Analytics with a dynamic serverless function that proxies requests to Plausible's API and event tracking endpoints.

## Key Changes
- Added new Cloudflare Worker function (`functions/pio/[[path]].js`) that:
  - Intercepts requests to `/pio/*` paths
  - Dynamically forwards them to `https://plausible.io` with the same method, headers, and body
  - Strips `set-cookie` headers from responses for security/privacy
  - Preserves response status and other headers
- Removed static Plausible Analytics redirects from `_redirects` file:
  - `/pio/js/pa-s49MQh6vkUW1n3PK9sukW.js` redirect
  - `/pio/api/event` redirect

## Implementation Details
The new proxy function uses a catch-all route pattern (`[[path]]`) to handle any path under `/pio/`, making it more flexible than the previous static redirects. It properly handles both GET requests (for script loading) and POST requests (for event tracking) while maintaining request integrity through header and body forwarding.

https://claude.ai/code/session_01QcQgA6RiWXidwa359VpyNJ