### PR TITLE
Update deployment platform from Netlify to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,4 @@
 
 ### Basics
 
-**www-coding4conservation** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Cloudflare](https://www.cloudflare.com).
-
-[![Netlify Status](https://api.netlify.com/api/v1/badges/868286f8-b544-43a5-932d-f2711605221d/deploy-status)](https://app.netlify.com/sites/coding4conservation/deploys)
+**www-coding4conservation** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Cloudflare Pages](https://pages.cloudflare.com) with a domain registered via [Cloudflare](https://www.cloudflare.com).


### PR DESCRIPTION
## Summary
Updated the README to reflect a change in the site's deployment infrastructure from Netlify to Cloudflare Pages.

## Changes
- Replaced Netlify with Cloudflare Pages as the deployment platform in the project description
- Removed the Netlify deployment status badge, as it is no longer applicable with the new deployment platform

## Details
The site continues to use Jekyll for static site generation and Cloudflare for domain registration. The deployment method has been consolidated to use Cloudflare's native Pages service instead of maintaining a separate Netlify deployment.

https://claude.ai/code/session_01SeBhMo5G4sXXs7ciNQPDTX